### PR TITLE
Fix issue with loading contents of file

### DIFF
--- a/methods/misc/synchroniseScripts.js
+++ b/methods/misc/synchroniseScripts.js
@@ -54,7 +54,7 @@ function getFileContents(path, file, headers) {
 		const html = await fetch(url, { headers }).then((res) => res.text());
 
 		const $ = cheerio.load(html);
-		const contents = $('#edit-file-content').text();
+		const contents = $('#code').text();
 		resolve(contents);
 	})
 }


### PR DESCRIPTION
# The issue
Party decided to add another ID to the tag which contains the contents of the file. Cheerio, naturally, only reads the first ID of the element because of course, tags aren't meant to have multiple ID's. This new ID "code" comes before the old ID "edit-file-content" so cheerio reads this.
This issue blocks users from syncing files, as it cannot get their content.
# The fix
This pull request fixes this by switching the ID used in the selector to "code" so CFM can correctly locate the content.