### PR TITLE
Add support for accounts with 2FA enabled

### DIFF
--- a/src/CubedFileManager.ts
+++ b/src/CubedFileManager.ts
@@ -306,6 +306,24 @@ export default class CubedFileManager {
 		})
 	}
 
+	/**
+	 * Gets a 2fa code from the user and attempts to use it to login
+	 * @param html The HTML of the 2 factor authentication page returned upon login attempt
+	 * @param session The session of the user
+	 * @returns 
+	 */
+	public twoFactorAuthenticationRequired(html: string, session: string) : Promise<boolean> {
+		return new Promise(async (resolve) => {
+			this.message_info('Account has two factor authentication enabled')
+			
+			const code = await normalQuestion(`Please enter your 2FA code. `)
+			const response = await this.requestManager.twoFactorAuthentication(html, code, session)
+
+			if (!response) this.message_error('Invalid 2FA code entered')
+
+			resolve(response)
+		})
+	}
 
 	/**
 	 * Session verification


### PR DESCRIPTION
Currently CFM just gives an error, saying it failed to login, if an account has 2FA enabled. This PR aims to fix that by allowing the user to enter their 2FA code when they login if it is detected that they have two factor authentication enabled.

The implementation is designed to work with the current system without getting in the way of anything, so all functions can operate as usual.