### PR TITLE
Add autoSync option to CubedCraft.json

### DIFF
--- a/src/CubedFileManager.ts
+++ b/src/CubedFileManager.ts
@@ -227,6 +227,14 @@ export default class CubedFileManager {
 			const uploader = new BackupLoader(this);
 			await uploader.start();
 			process.exit(0);
+		} 
+		
+		if (this.settingsManager.settings?.autoSync) {
+			this.message_info("autoSync is enabled in CubedCraft.json")
+			this.message_info("Starting to download all scripts from the server...");
+			const downloader = new FileDownloader(this);
+			await downloader.downloadFiles("");
+			this.message_success("All files were downloaded")
 		}
 
 		if (this.arguments.livesync || this.settingsManager.settings?.livesync) {

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -16,7 +16,8 @@ export default class SettingsManager {
 		logErrors: false,
 		baseDir: "plugins/Skript/scripts",
 		livesync: false,
-		extensions: [".sk"]
+		extensions: [".sk"],
+		autoSync: false
 	}
 
 	constructor(instance: CubedFileManager) {

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -6,4 +6,5 @@ export interface Settings {
 	baseDir: string | undefined;
 	livesync: boolean | undefined;
 	extensions: string[];
+	autoSync: boolean | undefined;
 }


### PR DESCRIPTION
This pull request is to add an option to the CubedCraft.json config called autoSync. When enabled, this feature will automatically sync the scripts from server to the user's directory every time the file watcher is launched.

This feature is useful because if multiple users are working on a server, if someone forgets to sync their scripts when they launch CFM they will be saving an outdated version. This also saves people times, as there is no need to run `cfm --sync` and then `cfm`. 

It syncs the files before the file watcher is started. By default the option is disabled.
![image](https://user-images.githubusercontent.com/66561610/140165518-ab49f60b-7054-4d73-b8d4-5c7ae06cd0c2.png)
