### PR TITLE
Add Node.js version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A CLI that helps scripters easily work on their playerservers on the CubedCraft network.",
   "exports": "./dist/index.js",
   "engines": {
-    "node": ">=12.20.0"
+    "node": ">=16.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,17 @@ import minimist from 'minimist';
 
 
 /**
+ * Make sure user is on a compatible NodeJS version
+ */
+
+if (typeof process !== 'undefined' && parseInt(process.versions.node.split('.')[0]) < 16) {
+	console.error(chalk.red('CubedFileManager is unable to start due to an issue that must be resolved.'))
+	console.error(chalk.grey('[') + chalk.redBright("x") + chalk.grey("]") + " " + 'Your Node.js version is currently', process.versions.node)
+	console.error(chalk.grey('[') + chalk.redBright("x") + chalk.grey("]") + " " + 'Please update it to version 16 or higher from https://nodejs.org/ to be able to use CubedFileManager!')
+	process.exit(1)
+}
+
+/**
  * Notify users if a new update is ready
  */
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'));


### PR DESCRIPTION
This pull request is to check the user's Node.js version when using CubedFileManager, if their version is below v16 CFM will exit, giving the user a message to update.

This is necessary because on Node.js v14 CFM does not work due to the fact it utilizes the replaceAll function which was only added to the string prototype in v15 of Node.js.

CubedFileManager is built for v16 of Node.js and therefore it makes sense to gets users to use the same version, especially as v16 is now the main version of Node.

Here is the message it gives: (please ignore the fact it tells me my version is v16, that's because it is, I was just testing it on v16 and I set it to error for that version)
![image](https://user-images.githubusercontent.com/66561610/140170651-7c8f5c38-5e6e-4bae-b80f-de2b7f7808d9.png)
