### PR TITLE
Fix update-notifier not showing global flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import minimist from 'minimist';
  * Notify users if a new update is ready
  */
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'));
-update_notifier({ pkg, updateCheckInterval: 0 }).notify();
+update_notifier({ pkg, updateCheckInterval: 0 }).notify({ isGlobal: true });
 
 /**
  * Write a banner saying the package name


### PR DESCRIPTION
For whatever reason, update-notifier was failing to register the package is installed globally and therefore requires the `-g` flag.
This PR forces update-notifier to register the package as being globally installed - this is fine considering the only reasonable use case for CFM is a global install.