### PR TITLE
Bring back failed to login error

### DIFF
--- a/src/CubedFileManager.ts
+++ b/src/CubedFileManager.ts
@@ -93,13 +93,13 @@ export default class CubedFileManager {
 		}
 	}
 
-	private async init() : Promise<any> {
+	private async init(failed = false) : Promise<any> {
 
 		/**
 		 * Logging into their account & getting a session ID
 		 */
 		let loginMethod: LoginMethods;
-		if (!this.settingsManager.exists || this.cryptoManager.username.length < 1 || this.cryptoManager.password.length < 1) 
+		if (!this.settingsManager.exists || this.cryptoManager.username.length < 1 || this.cryptoManager.password.length < 1 || failed) 
 			loginMethod = await this.askLoginMethod();
 		else loginMethod = LoginMethods.AUTOMATIC;
 
@@ -124,7 +124,7 @@ export default class CubedFileManager {
 		
 		const response = await this.requestManager.login(username, password);
 		if (response == null) {
-			return this.init();
+			return this.init(true);
 		}
 
 		if (loginMethod == LoginMethods.MANUAL) {

--- a/src/CubedFileManager.ts
+++ b/src/CubedFileManager.ts
@@ -124,7 +124,6 @@ export default class CubedFileManager {
 		
 		const response = await this.requestManager.login(username, password);
 		if (response == null) {
-			this.message_error(`Failed to log in as ${username}`)
 			return this.init();
 		}
 
@@ -345,6 +344,12 @@ export default class CubedFileManager {
 				process.exit(0);
 			}
 			const response = await this.requestManager.login(this.temp_username, this.temp_password);
+
+			if (response == null) {
+				this.message_error('Failed to log back in. Closing system.');
+				process.exit(0);
+			}
+
 			await this.requestManager.selectServer(this.temp_server);
 
 			this.sessionToken = response!;

--- a/src/CubedFileManager.ts
+++ b/src/CubedFileManager.ts
@@ -124,6 +124,7 @@ export default class CubedFileManager {
 		
 		const response = await this.requestManager.login(username, password);
 		if (response == null) {
+			this.message_error(`Failed to log in as ${username}`)
 			return this.init();
 		}
 

--- a/src/lib/RequestsManager.ts
+++ b/src/lib/RequestsManager.ts
@@ -435,6 +435,7 @@ export default class RequestManager {
 					this.instance.message_success(`Logged in as ${username}`)
 					resolve(cookie);
 				} else if (response == ResponseTypes.FAILURE) {
+					this.instance.message_error(`Failed to log in as ${username}`)
 					resolve(null);
 				} else if (response == ResponseTypes.TFA) {
 					await this.instance.ask2FACode(html, cookie);

--- a/src/lib/RequestsManager.ts
+++ b/src/lib/RequestsManager.ts
@@ -574,8 +574,19 @@ export default class RequestManager {
 			const isExpired = await this.sessionIsExpired();
 
 			if (isExpired) {
+				this.instance.message_info('Current session expired. Refreshing it!');
+
 				const token = await this.login(this.instance.temp_username!, this.instance.temp_password!);
+
+				if (token == null) {
+					this.instance.message_error('Failed to log back in. Closing system.');
+					process.exit(0);
+				}
+
 				this.instance.sessionToken = token!;
+				this.instance.headers = {
+					cookie: `PHPSESSID=${token};`
+				}
 				await this.selectServer(this.instance.temp_server!);
 			}
 			resolve();


### PR DESCRIPTION
Sorry for most likely spamming your email with PR request stuff Super.

Anyway, I noticed the error for failed to login was removed during the 2FA implementation, this brings it back.
I'm not sure if this should be merged yet as I feel support for this should be added to the session renew as well, but that takes slightly more work.