### PR TITLE
Validate extensions on socket file events + somewhat allow for better editing of files from LiveSync

### DIFF
--- a/src/lib/FileWatcher.ts
+++ b/src/lib/FileWatcher.ts
@@ -44,13 +44,13 @@ export default class FileWatcher {
 			const file = p.basename(path);
 			if (!this.isAllowedExtension(file)) return;
 			
-			if (this.instance.socketManager?.lastUpdatedFile == file) return;
+			// Read file
+			const content = readFileSync(path, 'utf8');
+
+			if (this.instance.socketManager?.lastUpdatedFile == file && this.instance.socketManager?.lastUpdatedContent == content) return;
 
 			// Check session
 			await this.instance.requestManager.checkAndUpdateSession();
-
-			// Read file
-			const content = readFileSync(path, 'utf8');
 			
 			// Folder support
 			if (this.instance.folderSupport) {
@@ -66,13 +66,14 @@ export default class FileWatcher {
 			const file = p.basename(path);
 			if (!this.isAllowedExtension(file)) return;
 
-			if (this.instance.socketManager?.lastUpdatedFile == file) return;
+			// Read file
+			const content = readFileSync(path, 'utf-8');
+
+			// Checking that this chance isn't from the socket
+			if (this.instance.socketManager?.lastUpdatedFile == file && this.instance.socketManager?.lastUpdatedContent == content) return;
 
 			// Check session
 			await this.instance.requestManager.checkAndUpdateSession();
-
-			// Read file
-			const content = readFileSync(path, 'utf-8');
 
 			// Folder support
 			if (this.instance.folderSupport) {


### PR DESCRIPTION
Ok I promise this is the last PR of the day, I've just felt really motivated for some reason. 

This PR addresses two things (I know it's probs best in 2 PR's but they cover the same topic, but feel free to ask for something to be changed).

**1) For incoming file events on live sync, check that the extension is a supported extension**
This is important for 2 reasons, firstly, it addresses a possible security concern of user's, where if other users are connected to the same live sync they could modify files dangerously on the user's computer (e.g. sending a command to modify the CFM source code and grab the user's login details next time they launch). Now, incoming events will only be handled if the file it's editing is in the allowed extensions.
Secondly, this is useful just because some people won't want to deal with some extensions, makes no sense to handle events for files that aren't in supported extensions.

**2) Allow for somewhat better editing of files that were edited by liveSync**
Previously, if you saved an edit to a file that had been created (or modified) through liveSync before, the edit would not be handled. Now the edit will not be handled only if the content of the file is also the same as the most recently received through liveSync. The only real flaw with this, is files just created through live sync still can't be deleted, but I don't see it being that great a problem.
This is not a perfect fix, and maybe someone in the future could do better, but the way I see it is it's better than nothing.
I think the ideal way to tackle it, is to save the exact info of the event received and then check against that e.g. action (create, edit, delete), content, path,

Ok now I should rest.