### PR TITLE
Add better login configuration for CubedCraft.json

### DIFF
--- a/src/CubedFileManager.ts
+++ b/src/CubedFileManager.ts
@@ -103,7 +103,7 @@ export default class CubedFileManager {
 		let notSaved = !this.settingsManager.exists || !this.settingsManager.settings?.login?.useSavedAccount && (!this.settingsManager.settings?.login?.username || !this.settingsManager.settings?.login?.password)
 
 		let loginMethod: LoginMethods;
-		if (notSaved || this.cryptoManager.username.length < 1 || this.cryptoManager.password.length < 1 || failed)
+		if (notSaved || (this.settingsManager.settings?.login?.useSavedAccount && this.cryptoManager.username.length < 1) || (this.settingsManager.settings?.login?.useSavedAccount && this.cryptoManager.password.length < 1) || failed)
 			loginMethod = await this.askLoginMethod();
 		else loginMethod = LoginMethods.AUTOMATIC;
 

--- a/src/CubedFileManager.ts
+++ b/src/CubedFileManager.ts
@@ -98,8 +98,12 @@ export default class CubedFileManager {
 		/**
 		 * Logging into their account & getting a session ID
 		 */
+
+		// Gets boolean of whether or not they have pre-entered login details either in CubedCraft.json or saved in CFM that they wish to use
+		let notSaved = !this.settingsManager.exists || !this.settingsManager.settings?.login?.useSavedAccount && (!this.settingsManager.settings?.login?.username || !this.settingsManager.settings?.login?.password)
+
 		let loginMethod: LoginMethods;
-		if (!this.settingsManager.exists || this.cryptoManager.username.length < 1 || this.cryptoManager.password.length < 1 || failed) 
+		if (notSaved || this.cryptoManager.username.length < 1 || this.cryptoManager.password.length < 1 || failed)
 			loginMethod = await this.askLoginMethod();
 		else loginMethod = LoginMethods.AUTOMATIC;
 
@@ -109,9 +113,17 @@ export default class CubedFileManager {
 		if (loginMethod == LoginMethods.MANUAL) {
 			username = await normalQuestion('What is your username? ');
 			password = await hiddenQuestion('What is your password? ');
-		} else if (loginMethod == LoginMethods.AUTOMATIC || loginMethod == LoginMethods.RECONFIGURE) {
+		} else if (loginMethod == LoginMethods.RECONFIGURE) {
 			username = this.cryptoManager.username;
 			password = this.cryptoManager.password;
+		} else if (loginMethod == LoginMethods.AUTOMATIC) {
+			if (this.settingsManager.settings?.login?.useSavedAccount) {
+				username = this.cryptoManager.username;
+				password = this.cryptoManager.password;
+			} else {
+				username = this.settingsManager.settings?.login?.username
+				password = this.settingsManager.settings?.login?.password
+			}
 		}
 		
 		if (!username || !password) {

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -11,6 +11,11 @@ export default class SettingsManager {
 
 	private defaultSettings: Settings = {
 		username: '',
+		login: {
+			useSavedAccount: true,
+			username: '',
+			password: ''
+		},
 		server: '',
 		folderSupport: false,
 		logErrors: false,

--- a/src/types/LoginTypes.ts
+++ b/src/types/LoginTypes.ts
@@ -1,7 +1,8 @@
 export enum LoginMethods {
 	MANUAL,
 	RECONFIGURE,
-	AUTOMATIC
+	AUTOMATIC,
+	CUSTOM
 }
 
 export enum ResponseTypes {

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -1,5 +1,10 @@
 export interface Settings {
 	username: string | undefined,
+	login: {
+		useSavedAccount: boolean | undefined;
+		username: string;
+		password: string;
+	}
 	server: string | undefined,
 	folderSupport: boolean | undefined,
 	logErrors: boolean | undefined,


### PR DESCRIPTION
This PR is to add increased configuration capabilities in CubedCraft.json for managing account logins.
![image](https://user-images.githubusercontent.com/66561610/140609840-649d6267-b181-4285-98a2-641532d8369e.png)
Most of the configuration is self explanatory; `useSavedAccount`, if set to true, makes CFM use the account saved in data.json if there is one. If `useSavedAccount` is false but `username` and `password` are filled in, CFM will attempt to login with those details. If `username` and `password` are not filled in, and `useSavedAccount` is false, CFM will ask the user for a login as per usual.

By default `useSavedAccount` is set to `true`. I believe this feature is useful as if multiple accounts are used across servers, for whatever reason (e.g. you own a server on your alt) you can login with those details for that work space.

It is not ideal that there are 2 `username` fields, one being for the login, one being for the name. In future I think it would be a good idea to add a feature where CFM gets their username when loading through a request and then uses that for messages to send to console.

![image](https://user-images.githubusercontent.com/66561610/140610002-da2520de-066a-43ed-899b-0e17da3ad419.png)
