### PR TITLE
Fetch the username of user upon login + fix bugs

### DIFF
--- a/src/CubedFileManager.ts
+++ b/src/CubedFileManager.ts
@@ -78,10 +78,6 @@ export default class CubedFileManager {
 			this.folderSupport = true;
 		} 
 
-		if (this.arguments.name || this.arguments.n || this.settingsManager.settings?.username) {
-			this.username = (this.arguments.name || this.arguments.n || this.settingsManager.settings?.username);
-		}
-
 		if (this.arguments.logerrors || this.arguments.logerr || this.settingsManager.settings?.logErrors) {
 			this.logErrors = true;
 		}
@@ -333,7 +329,7 @@ export default class CubedFileManager {
 			const response = await normalQuestion("Enter 2FA code from your authenticator app: ");
 
 			// Attempt to run it through the 2FA stuff
-			const success = this.requestManager.submit2FACode(response, html, cookie);
+			const success = await this.requestManager.submit2FACode(response, html, cookie);
 			if (!success) {
 				this.message_error("Invalid 2FA code. Please try again...");
 				return resolve(await this.ask2FACode(html, cookie));

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ const helpMessage = `
 let argv;
 let path;
 
-if (!(process.argv[2] == basename(process.argv[0])) && !process.argv.includes('-help') && !process.argv.includes('--help')) {
+if (!(process.argv[2] == basename(process.argv[0])) && !process.argv.includes('-help') && !process.argv.includes('--help') && !process.argv.includes('--h') && !process.argv.includes('-h')) {
 	argv = minimist(process.argv.slice(2));
 	path = process.cwd();
 } else if (process.argv.includes('-help') || process.argv.includes('--help') || process.argv.includes('-h') || process.argv.includes('--h')) {

--- a/src/lib/SettingsManager.ts
+++ b/src/lib/SettingsManager.ts
@@ -10,7 +10,6 @@ export default class SettingsManager {
 	public exists: boolean = false;
 
 	private defaultSettings: Settings = {
-		username: '',
 		login: {
 			useSavedAccount: true,
 			username: '',
@@ -54,7 +53,7 @@ export default class SettingsManager {
 	public createJsonFile() {
 		const exists = fs.existsSync(path.join(this.instance.rootDir, 'CubedCraft.json'));
 		if (exists) {
-			this.instance.message_error(" CubedCraft.json already exists!");
+			this.instance.message_error("CubedCraft.json already exists!");
 			return;
 		}
 

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -1,5 +1,4 @@
 export interface Settings {
-	username: string | undefined,
 	login: {
 		useSavedAccount: boolean | undefined;
 		username: string;


### PR DESCRIPTION
**The change**
This PR is to stop the user from having to input their username (either in the `--username` flag or in `CubedCraft.json`) and instead fetch their username upon login.
It doesn't take the username they used for logging in due to the fact that some people might use their email.

**Why?**
First reason is convenience, having who did an action logged in chat is pretty useful but it's a nuisance for users to have to add an extra flag. It also means users don't have to discover the feature and instead adds a standard of adding the username to the message.
Thirdly, and the main reason that triggered me to add this, with the changing of `CubedCraft.json` to have a dedicated `login` field, I can foresee it being confusing for users to have 2 username fields.

**Other changes**
This PR also fixes 2 other minor issues I stumbled across whilst testing it. Yes, I know it's not great practice to have multiple bug fixes in one PR however these were pretty easy fixes that I can just slot in.
The first of these fixes was that 2FA failed to detect invalid 2FA code entries because it wasn't awaiting the result. The second of these is that the `-h` and `--h` flags, although intended to work, didn't work due to them not being filtered out.