### PR TITLE
Add full escaped characters support to console error fetching

### DIFF
--- a/src/util/getSkriptErrors.ts
+++ b/src/util/getSkriptErrors.ts
@@ -1,6 +1,12 @@
 export default (console_data: string, name: string) => {
 
-	console_data = console_data.replace(/<br \/>/g, "").replace(/&quot;/g,'"')
+	console_data = console_data
+	.replace(/<br \/>/g, "")
+	.replace(/&quot;/g,'"')
+	.replace(/&amp;/g, '&')
+	.replace(/&lt;/g, '<')
+	.replace(/&gt;/g, '>')
+	
 	const lines = console_data.split('\n');
 
 	let reading_error = false;


### PR DESCRIPTION
Right now only quotations are parsed when parsing escaped content from console. With this PR all escaped content (<, >, &, ") will be parsed before showing it to the user.