### PR TITLE
Add --deletedefaults flag to remove default Skript files

### DIFF
--- a/src/CubedFileManager.ts
+++ b/src/CubedFileManager.ts
@@ -17,6 +17,7 @@ import SocketManager from "./util/SocketManager.js";
 import { existsSync, writeFileSync } from "fs";
 import { join } from "path";
 import BackupLoader from "./util/backupScriptsToServer.js";
+import deleteDefaultScripts from "./util/deleteDefaultScripts.js";
 
 export default class CubedFileManager {
 
@@ -235,7 +236,11 @@ export default class CubedFileManager {
 			const uploader = new BackupLoader(this);
 			await uploader.start();
 			process.exit(0);
-		} 
+		} else if (this.arguments.deletedefaults) {
+			this.message_info("Deleting all default scripts on the server...");
+			await deleteDefaultScripts(this);
+			process.exit(0);
+		}
 		
 		if (this.settingsManager.settings?.autoSync) {
 			this.message_info("autoSync is enabled in CubedCraft.json")
@@ -365,6 +370,16 @@ export default class CubedFileManager {
 				cookie: `PHPSESSID=${response};`
 			}
 		}
+	}
+
+	/*
+		Fix paths to be compliant with how Cubed handles paths
+	*/
+	public fixPath(path: string) : string {
+		path = path.replaceAll('\\', '/')
+		if (path.endsWith('/')) path = path.slice(0, path.length - 1)
+		if (!path.startsWith('/')) path = '/' + path
+		return path
 	}
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ const helpMessage = `
 			--sync Synchronise all files from the file manager to your machine (will work with folders if there are any in the file manager)
 			--livesync Create a websocket connection with the CubedFileManager server. If anyone working on the same server edits a file and is using cubedfilemanager, it will get updated immediatly on your local filesystem as well.
 			--backup Back all local files to plugins/Skript/backups/backup-<time>/
+			--deletedefaults Removes all default scripts on the server
 			--help -help Show this help menu
 `
 let argv;

--- a/src/lib/RequestsManager.ts
+++ b/src/lib/RequestsManager.ts
@@ -240,8 +240,8 @@ export default class RequestManager {
 
 			const deleteURL = "https://playerservers.com/dashboard/filemanager/&action=delete";
 			const params = new URLSearchParams();
-			params.append("targetFile", `/${this.instance.baseDir}/${path}/-${name}`);
-			params.append("target", `/${this.instance.baseDir}/${path}/-${name}`);
+			params.append("targetFile", `/${this.instance.baseDir}/${path}/${name.startsWith('-') ? name : '-' + name}`);
+			params.append("target", `/${this.instance.baseDir}/${path}/${name.startsWith('-') ? name : '-' + name}`);
 			params.append("action", "delete");
 			params.append("token", editToken);
 

--- a/src/util/deleteDefaultScripts.ts
+++ b/src/util/deleteDefaultScripts.ts
@@ -1,0 +1,52 @@
+import CubedFileManager from "../CubedFileManager";
+import fetch from "node-fetch";
+
+export default async (instance: CubedFileManager) : Promise<void> => {
+    return new Promise(async (resolve) => {
+
+        // A (hopefully) definitive list of all default files Skript puts in the scripts folder upon first install
+        // Supports default files across different versions of Skript so not all files will be added on your server when Skript is installed
+        const defaultScripts = [
+            '-- Files prefixed with a hyphen are disabled! --',
+            '-command with cooldown.sk',
+            '-custom helmet.sk',
+            '-disable weather.sk',
+            '-eternal day.sk',
+            '-furnace automatisation.sk',
+            '-homes.sk',
+            '-item command.sk',
+            '-kill counter.sk',
+            '-nerf endermen.sk',
+            '-realistic drops.sk',
+            '-simple god mode.sk',
+            '-simple join and leave message.sk',
+            '-simple motd.sk',
+            '-teleport with compass.sk',
+            '-vanilla gui.sk',
+            '-plant with hoe.sk',
+            '-nerf endermen.sk',
+            '-kill counter.sk',
+            '-equip anything.sk',
+            '-drop fixes.sk',
+            '-block head.sk'
+        ]
+
+        // Get all files in the file manager
+        const url = `https://playerservers.com/queries/list_files/?dir=${instance.fixPath(instance.baseDir)}`;
+        const json: any = await fetch(url, { headers: instance.headers as any }).then((res) => res.json());
+
+        if (json.error) {
+            instance.message_error('An unknown error occurred whilst fetching the files in the base folder!')
+            process.exit()
+        }
+
+        for (const file of json.files) {
+            if (defaultScripts.includes(file.filename)) {
+                await instance.requestManager.removeFile(file.filename, '')
+            }
+        }
+
+        instance.message_info('Finished removing all default scripts')
+        resolve()
+    })
+}

--- a/src/util/syncScriptsToLocal.ts
+++ b/src/util/syncScriptsToLocal.ts
@@ -2,25 +2,26 @@ import fs from "fs";
 import path from "path";
 import CubedFileManager from "../CubedFileManager.js";
 import fetch from 'node-fetch';
+import { join } from "path";
 
 export default class FileDownloader {
 
 
-    private manager: CubedFileManager;
+    private instance: CubedFileManager;
 
-    constructor(manager: CubedFileManager) {
-        this.manager = manager;
+    constructor(instance: CubedFileManager) {
+        this.instance = instance;
     }
 
     public async downloadFiles(dir: string) {
         // Get all files in the file manager
-        const url = `https://playerservers.com/queries/list_files/?dir=/plugins/Skript/scripts${dir}`;
-        const json: any = await fetch(url, { headers: this.manager.headers as any }).then((res) => res.json());
+        const url = `https://playerservers.com/queries/list_files/?dir=${this.instance.fixPath(join(this.instance.baseDir, dir))}`;
+        const json: any = await fetch(url, { headers: this.instance.headers as any }).then((res) => res.json());
 
         // Looping through all files
         for (const file of json.files) {
-            const contents = await this.manager.requestManager.getFileContent(dir, file.filename);
-            const p = path.join(this.manager.rootDir, '.', dir);
+            const contents = await this.instance.requestManager.getFileContent(dir, file.filename);
+            const p = path.join(this.instance.rootDir, '.', dir);
             
             await fs.promises.mkdir(p, { recursive: true });
             fs.writeFileSync(path.join(p, file.filename), contents);


### PR DESCRIPTION
This PR adds the ability to use the flag `--deletedefaults` to remove all default scripts added by Skript.
It also changes sync to use baseDir as before it was using a hardcoded version of it.