### PR TITLE
Dont log create for every file when running backup

### DIFF
--- a/src/lib/RequestsManager.ts
+++ b/src/lib/RequestsManager.ts
@@ -22,9 +22,10 @@ export default class RequestManager {
 	 * @param name The name of te file
 	 * @param content The content of the file
 	 * @param rawPath The path to the file in the file manager
+	 * @param commands Whether or not to run reload and log commands upon create
 	 * @returns Promise that resolves when the file is made
 	 */
-	public createFile(name: string, content: string = "", rawPath: string) : Promise<void> {
+	public createFile(name: string, content: string = "", rawPath: string, commands: boolean = true) : Promise<void> {
 		return new Promise(async (resolve) => {
 			const headers = this.instance.headers;
 
@@ -73,9 +74,11 @@ export default class RequestManager {
 					spin.stop();
 					this.instance.message_log(`Created file ${fileName}.${fileExtension}`)
 
-					await this.sendCommand(`sk reload ${this.instance.folderSupport ? `${path}/${name}` : name}`)
-					await this.sendCommand(`sendmsgtoops &e${this.instance.username ? this.instance.username : ""} &fCreated${content.length ? " and enabled" : ""} &b${ this.instance.folderSupport ? `${path}/${name}` : name}`);
-					
+					if (commands) {
+						await this.sendCommand(`sk reload ${this.instance.folderSupport ? `${path}/${name}` : name}`)
+						await this.sendCommand(`sendmsgtoops &e${this.instance.username ? this.instance.username : ""} &fCreated${content.length ? " and enabled" : ""} &b${ this.instance.folderSupport ? `${path}/${name}` : name}`);
+					}
+
 					resolve();
 				})	
 			})

--- a/src/util/backupScriptsToServer.ts
+++ b/src/util/backupScriptsToServer.ts
@@ -12,6 +12,8 @@ export default class BackupLoader {
     }
 
     public async start() {
+        this.manager.requestManager.sendCommand(`sendmsgtoops &e${this.manager.username ? this.manager.username : ""} &fBacking up files.`)
+
         this.manager.baseDir = "plugins/Skript";
         if (!(await this.manager.requestManager.folderExists("/file-backups"))) {
             await this.manager.requestManager.createFolder("", "file-backups");
@@ -41,7 +43,7 @@ export default class BackupLoader {
                 if (this.manager.folderSupport) {
                     await this.manager.utilities.parseFolders(this.preparePath(path.join(dir, files[i])));
                 }
-                await this.manager.requestManager.createFile(files[i], contents, this.preparePath(path.join(dir, files[i])));
+                await this.manager.requestManager.createFile(files[i], contents, this.preparePath(path.join(dir, files[i])), false);
             }
         }
     }


### PR DESCRIPTION
Right now CFM absolutely spams chat when a backup is being made with `cfm --backup`. This PR changes the behavior of backup to not log every file created, as there is no need for this, confuses online staff who think loads of files are being created, instead it logs one singular message saying a backup is being created.