### PR TITLE
Fix crash when base directory does not exist on server (+ other error checking)

### DIFF
--- a/src/lib/RequestsManager.ts
+++ b/src/lib/RequestsManager.ts
@@ -349,6 +349,14 @@ export default class RequestManager {
 			const json = await fetch(url, { headers: headers as any })
 			.then((res) => res.json());
 
+			if (json.error && json.code === 5) {
+				this.instance.message_error(`Folder "${this.instance.baseDir}" does not exist on the server!`)
+				process.exit()
+			} else if (json.error) {
+				this.instance.message_error(`An unknown error occured fetching files from "${this.instance.baseDir}"!`)
+				process.exit()
+			}
+
 			// Checking if the file exists
 			const exists = json.files.some((c: any) => c.filename === file);
 			resolve(exists);

--- a/src/util/syncScriptsToLocal.ts
+++ b/src/util/syncScriptsToLocal.ts
@@ -17,6 +17,11 @@ export default class FileDownloader {
         const url = `https://playerservers.com/queries/list_files/?dir=/plugins/Skript/scripts${dir}`;
         const json: any = await fetch(url, { headers: this.manager.headers as any }).then((res) => res.json());
 
+        if (json.error) {
+            this.manager.message_error('An unknown error occured when downloading files from the server.')
+            process.exit()
+        }
+
         // Looping through all files
         for (const file of json.files) {
             const contents = await this.manager.requestManager.getFileContent(dir, file.filename);

--- a/src/util/syncScriptsToLocal.ts
+++ b/src/util/syncScriptsToLocal.ts
@@ -6,26 +6,26 @@ import fetch from 'node-fetch';
 export default class FileDownloader {
 
 
-    private manager: CubedFileManager;
+    private instance: CubedFileManager;
 
-    constructor(manager: CubedFileManager) {
-        this.manager = manager;
+    constructor(instance: CubedFileManager) {
+        this.instance = instance;
     }
 
     public async downloadFiles(dir: string) {
         // Get all files in the file manager
         const url = `https://playerservers.com/queries/list_files/?dir=/plugins/Skript/scripts${dir}`;
-        const json: any = await fetch(url, { headers: this.manager.headers as any }).then((res) => res.json());
+        const json: any = await fetch(url, { headers: this.instance.headers as any }).then((res) => res.json());
 
         if (json.error) {
-            this.manager.message_error('An unknown error occured when downloading files from the server.')
+            this.instance.message_error('An unknown error occured when downloading files from the server.')
             process.exit()
         }
 
         // Looping through all files
         for (const file of json.files) {
-            const contents = await this.manager.requestManager.getFileContent(dir, file.filename);
-            const p = path.join(this.manager.rootDir, '.', dir);
+            const contents = await this.instance.requestManager.getFileContent(dir, file.filename);
+            const p = path.join(this.instance.rootDir, '.', dir);
             
             await fs.promises.mkdir(p, { recursive: true });
             fs.writeFileSync(path.join(p, file.filename), contents);


### PR DESCRIPTION
If for example, skript hasn't been installed on the server, CFM will crash out because it tries to continue with it's process. 
This PR now checks if an error is returned from all query endpoints so errors are more cleanly handled and are more understandable for users.