### PR TITLE
Fixed Escape Character and Token Fetch

### DIFF
--- a/src/lib/RequestsManager.ts
+++ b/src/lib/RequestsManager.ts
@@ -657,6 +657,6 @@ function getDeleteToken(html: string) {
 	if (webJavaScript == null) return null;
 
 	// Getting the token (this is really hardcoded but I don't know a more efficient way to extract this)
-	const token = webJavaScript.split('\n')[2].split("token: \"")[1].split("\" });")[0];
+	const token = (webJavaScript.match(/token: \"([\w\d]+)\"/) as RegExpMatchArray)[1];
 	return token;
 } 

--- a/src/util/getSkriptErrors.ts
+++ b/src/util/getSkriptErrors.ts
@@ -6,6 +6,7 @@ export default (console_data: string, name: string) => {
 	.replace(/&amp;/g, '&')
 	.replace(/&lt;/g, '<')
 	.replace(/&gt;/g, '>')
+	.replace(/&#039;/g, '\'')
 	
 	const lines = console_data.split('\n');
 


### PR DESCRIPTION
This pull request is based on a bug discussed in CubedCraft's discord server (as the image below indicates).

**Here are the changes:**
- Added string conversion for the escape character `'`.
- Fixed the failure of token fetch on file deletion.


![image](https://user-images.githubusercontent.com/41904540/211160339-01cbc064-e042-4d8a-a8d1-08ff720fb294.png)
